### PR TITLE
[add]条件分けしてスタンプとテキストを返信

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -3,38 +3,6 @@ require 'line/bot'
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
-  def client
-    @client ||= Line::Bot::Client.new { |config|
-      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
-    }
-  end
-
-  STICKER_PACKAGE_ID = 446
-  STICKER_ID_BEGIN = 1988
-  STICKER_ID_END = 2027
-
-  # ランダムなスタンプのIDを返す
-  def pickup_random_sticker_id
-    return rand(STICKER_ID_BEGIN..STICKER_ID_END)
-  end
-
-  POSITIVE_TEXT_LIST = %w[なるほど 確かに そうだね すごい 最高だね 天才だわ]
-  NEGATIVE_TEXT_LIST = %w[何言ってんの それはない いい加減にして？ そうかなぁ]
-  POLITE_TEXT_LIST = %w[仰る通りです その通りですね ごもっともですね 興味深いですね 全くもって同感です]
-
-  # 任意のテキストリストからランダムに取得する
-  def pickup_random_text(type)
-    case type
-    when 'positive'
-      return POSITIVE_TEXT_LIST.sample
-    when 'negative'
-      return NEGATIVE_TEXT_LIST.sample
-    when 'polite'
-      return POLITE_TEXT_LIST.sample
-    end
-  end
-
   def callback
     body = request.body.read
     signature = request.env['HTTP_X_LINE_SIGNATURE']
@@ -65,4 +33,37 @@ class WebhookController < ApplicationController
     }
     head :ok
   end
+
+  private
+    def client
+      @client ||= Line::Bot::Client.new { |config|
+        config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+        config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+      }
+    end
+
+    STICKER_PACKAGE_ID = 446
+    STICKER_ID_BEGIN = 1988
+    STICKER_ID_END = 2027
+
+    # ランダムなスタンプのIDを返す
+    def pickup_random_sticker_id
+      return rand(STICKER_ID_BEGIN..STICKER_ID_END)
+    end
+
+    POSITIVE_TEXT_LIST = %w[なるほど 確かに そうだね すごい 最高だね 天才だわ]
+    NEGATIVE_TEXT_LIST = %w[何言ってんの それはない いい加減にして？ そうかなぁ]
+    POLITE_TEXT_LIST = %w[仰る通りです その通りですね ごもっともですね 興味深いですね 全くもって同感です]
+
+    # 任意のテキストリストからランダムに取得する
+    def pickup_random_text(type)
+      case type
+      when 'positive'
+        return POSITIVE_TEXT_LIST.sample
+      when 'negative'
+        return NEGATIVE_TEXT_LIST.sample
+      when 'polite'
+        return POLITE_TEXT_LIST.sample
+      end
+    end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -12,7 +12,8 @@ class WebhookController < ApplicationController
 
   def callback
     body = request.body.read
-
+    puts '-'*100
+    p request.body.read
     signature = request.env['HTTP_X_LINE_SIGNATURE']
     unless client.validate_signature(body, signature)
       head 470
@@ -24,17 +25,20 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
+          reply_message_list = %w[test1 test2 test3 test4 test5]
           message = {
             type: 'text',
-            text: event.message['text']
+            text: reply_message_list.sample
           }
           client.reply_message(event['replyToken'], message)
-        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-          response = client.get_message_content(event.message['id'])
-          tf = Tempfile.open("content")
-          tf.write(response.body)
+        else
+          message = {
+            type: "sticker",
+            packageId: "446",
+            stickerId: rand(1988..2027)
+          }
+          client.reply_message(event['replyToken'], message)
         end
-        
       end
     }
     head :ok

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -10,10 +10,33 @@ class WebhookController < ApplicationController
     }
   end
 
+  STICKER_PACKAGE_ID = 446
+  STICKER_ID_BEGIN = 1988
+  STICKER_ID_END = 2027
+
+  # ランダムなスタンプのIDを返す
+  def pickup_random_sticker_id
+    return rand(STICKER_ID_BEGIN..STICKER_ID_END)
+  end
+
+  POSITIVE_TEXT_LIST = %w[なるほど 確かに そうだね すごい 最高だね 天才だわ]
+  NEGATIVE_TEXT_LIST = %w[何言ってんの それはない いい加減にして？ そうかなぁ]
+  POLITE_TEXT_LIST = %w[仰る通りです その通りですね ごもっともですね 興味深いですね 全くもって同感です]
+
+  # 任意のテキストリストからランダムに取得する
+  def pickup_random_text(type)
+    case type
+    when 'positive'
+      return POSITIVE_TEXT_LIST.sample
+    when 'negative'
+      return NEGATIVE_TEXT_LIST.sample
+    when 'polite'
+      return POLITE_TEXT_LIST.sample
+    end
+  end
+
   def callback
     body = request.body.read
-    puts '-'*100
-    p request.body.read
     signature = request.env['HTTP_X_LINE_SIGNATURE']
     unless client.validate_signature(body, signature)
       head 470
@@ -25,17 +48,16 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          reply_message_list = %w[test1 test2 test3 test4 test5]
           message = {
             type: 'text',
-            text: reply_message_list.sample
+            text: pickup_random_text('positive')
           }
           client.reply_message(event['replyToken'], message)
         else
           message = {
             type: "sticker",
-            packageId: "446",
-            stickerId: rand(1988..2027)
+            packageId: STICKER_PACKAGE_ID,
+            stickerId: pickup_random_sticker_id
           }
           client.reply_message(event['replyToken'], message)
         end


### PR DESCRIPTION
## 実装の背景・目的

botの基本となる返信の仕組みを実装

## やったこと

- テキストが来たらテキストの配列からランダムに一つを返信
- テキスト以外が来たらランダムにスタンプを一つ返信

## 補足

- テキストの配列はどこか別の場所に入れたほうが良いでしょうか？