### PR TITLE
[add]定期実行のロジックを追加

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -13,7 +13,7 @@ class WebhookController < ApplicationController
     
     events = client.parse_events_from(body)
 
-    events.each { |event|
+    events.each do |event|
       case event
       # グループ参加時
       when Line::Bot::Event::Join
@@ -30,7 +30,7 @@ class WebhookController < ApplicationController
         text = event["message"]["text"]
         message = Message.create({group_id: group.id, message_type: message_type, text: text})
       end
-    }
+    end
     head :ok
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module RubyGettingStarted
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.0
-
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
## 実装の背景・目的

10分以上返信がなかったグループにメッセージを送りたい

## やったこと

- メッセージのテーブルを参照して、20分以内にメッセージがあったグループのうち直近の10分でメッセージがなかったものに対してpush_messageの送信を行うロジックを実装しました