### PR TITLE
[add]会話を止めた個人への通知を実装

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -25,10 +25,19 @@ class WebhookController < ApplicationController
         Group.find_by(group_id: group_id).destroy
       # メッセージ受信時
       when Line::Bot::Event::Message
-        group = Group.find_by(group_id: event['source']['groupId'])
-        message_type = event["message"]["type"]
-        text = event["message"]["text"]
-        message = Message.create({group_id: group.id, message_type: message_type, text: text})
+        if event['source']['type'] == 'group'
+          group = Group.find_by(group_id: event['source']['groupId'])
+          message_type = event["message"]["type"]
+          user_id = event['source']['userId']
+          text = event["message"]["text"]
+          message = Message.create({group_id: group.id, message_type: message_type, user_id: user_id, text: text})
+        else
+          message = {
+            type: 'text',
+            text: 'グループに招待してご利用ください'
+          }
+          client.reply_message(event['replyToken'], message)
+        end
       end
     end
     head :ok

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -30,7 +30,7 @@ class WebhookController < ApplicationController
           message_type = event["message"]["type"]
           user_id = event['source']['userId']
           text = event["message"]["text"]
-          message = Message.create({group_id: group.id, message_type: message_type, user_id: user_id, text: text})
+          message = Message.create(group_id: group.id, message_type: message_type, user_id: user_id, text: text)
         else
           message = {
             type: 'text',

--- a/db/migrate/20221024023610_create_messages.rb
+++ b/db/migrate/20221024023610_create_messages.rb
@@ -4,8 +4,9 @@ class CreateMessages < ActiveRecord::Migration[6.0]
       t.references :group, null: false, foreign_key: true
       t.timestamp :posted_at, null: false
       t.string :message_type, null: false
+      t.string :user_id, null: false
       t.string :text
-
+      
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2022_10_24_023610) do
     t.bigint "group_id", null: false
     t.datetime "posted_at", null: false
     t.string "message_type", null: false
+    t.string "user_id", null: false
     t.string "text"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -18,6 +18,12 @@ task :push_message => :environment do
           text: pickup_random_text('positive')
         }
         client.push_message(group_id, message)
+        # 個人へのメッセージを送信
+        message = {
+          type: 'text',
+          text: 'あなたの最後の一言「' + latest_message.text + '」によってグループの会話が止まりました。'
+        }
+        client.push_message(latest_message.user_id, message)
       else
         message = {
           type: "sticker",

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -21,7 +21,7 @@ task :push_message => :environment do
         # 個人へのメッセージを送信
         message = {
           type: 'text',
-          text: 'あなたの最後の一言「' + latest_message.text + '」によってグループの会話が止まりました。'
+          text: "あなたの最後の一言「#{latest_message.text}」によってグループの会話が止まりました。"
         }
         client.push_message(latest_message.user_id, message)
       else


### PR DESCRIPTION
## 実装の背景・目的

グループの会話を止めた自覚を持ってもらいたい

## やったこと

- グループの最後の一言となるメッセージをおくったユーザーに対して、個人チャットでメッセージを送信する
- 個人チャットでメッセージを送ってきた場合、グルでの利用を促す