### PR TITLE
[add]usersテーブル、group_usersテーブルの追加

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -26,7 +26,7 @@ class WebhookController < ApplicationController
       # メッセージ受信時
       when Line::Bot::Event::Message
         if event['source']['type'] == 'group'
-          group = Group.find_by(line_group_id: event['source']['groupId'])
+          group = Group.find_by!(line_group_id: event['source']['groupId'])
           user = User.find_or_create_by(line_user_id: event['source']['userId'])
           GroupUser.find_or_create_by(group_id: group.id, user_id: user.id)
           message_type = event["message"]["type"]

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -17,20 +17,21 @@ class WebhookController < ApplicationController
       case event
       # グループ参加時
       when Line::Bot::Event::Join
-        group_id = event['source']['groupId']
-        group = Group.create(group_id: group_id)
+        line_group_id = event['source']['groupId']
+        group = Group.create(line_group_id: line_group_id)
       # グループ退会時
       when Line::Bot::Event::Leave
-        group_id = event['source']['groupId']
-        Group.find_by(group_id: group_id).destroy
+        line_group_id = event['source']['groupId']
+        Group.find_by(line_group_id: line_group_id).destroy
       # メッセージ受信時
       when Line::Bot::Event::Message
         if event['source']['type'] == 'group'
-          group = Group.find_by(group_id: event['source']['groupId'])
+          group = Group.find_by(line_group_id: event['source']['groupId'])
+          user = User.find_or_create_by(line_user_id: event['source']['userId'])
+          GroupUser.find_or_create_by(group_id: group.id, user_id: user.id)
           message_type = event["message"]["type"]
-          user_id = event['source']['userId']
           text = event["message"]["text"]
-          message = Message.create(group_id: group.id, message_type: message_type, user_id: user_id, text: text)
+          message = Message.create(group_id: group.id, user_id: user.id, message_type: message_type, text: text)
         else
           message = {
             type: 'text',

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,6 @@
 class Group < ApplicationRecord
   has_many :messages, dependent: :destroy
+  has_many :users, through: :group_users
+  has_many :group_users
+  accepts_nested_attributes_for :group_users
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,5 @@
 class Message < ApplicationRecord
   belongs_to :group
+  belongs_to :user
   attribute :posted_at, :datetime, default: -> {Time.now}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+    has_many :messages
+    has_many :groups, through: :group_users
+    has_many :group_users
+end

--- a/db/migrate/20221024021439_create_groups.rb
+++ b/db/migrate/20221024021439_create_groups.rb
@@ -1,10 +1,10 @@
 class CreateGroups < ActiveRecord::Migration[6.0]
   def change
     create_table :groups do |t|
-      t.string :group_id, null: false
+      t.string :line_group_id, null: false
 
       t.timestamps
     end
-    add_index :groups, :group_id, unique: true
+    add_index :groups, :line_group_id, unique: true
   end
 end

--- a/db/migrate/20221024022439_create_users.rb
+++ b/db/migrate/20221024022439_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :line_user_id, null: false
+
+      t.timestamps
+    end
+    add_index :users, :line_user_id, unique: true
+  end
+end

--- a/db/migrate/20221027050726_create_group_users.rb
+++ b/db/migrate/20221027050726_create_group_users.rb
@@ -1,0 +1,10 @@
+class CreateGroupUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :group_users do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_24_023610) do
+ActiveRecord::Schema.define(version: 2022_10_27_050726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "groups", force: :cascade do |t|
-    t.string "group_id", null: false
+  create_table "group_users", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["group_id"], name: "index_groups_on_group_id", unique: true
+    t.index ["group_id"], name: "index_group_users_on_group_id"
+    t.index ["user_id"], name: "index_group_users_on_user_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "line_group_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["line_group_id"], name: "index_groups_on_line_group_id", unique: true
   end
 
   create_table "messages", force: :cascade do |t|
@@ -33,6 +42,13 @@ ActiveRecord::Schema.define(version: 2022_10_24_023610) do
     t.index ["group_id"], name: "index_messages_on_group_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "line_user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
+  end
+
   create_table "widgets", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -41,5 +57,7 @@ ActiveRecord::Schema.define(version: 2022_10_24_023610) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
   add_foreign_key "messages", "groups"
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -9,7 +9,7 @@ task :push_message => :environment do
     # 同じグループの中で一番新しいメッセージを取得
     latest_message = messages.first
     # 最新のメッセージが現在時刻より10分以上前に送られている場合、最後の一言と判断してpush_messageを送信
-    if latest_message.posted_at >= time_10min_ago
+    if latest_message.posted_at <= time_10min_ago
       # 最後のメッセージがテキストならテキスト、それ以外ならスタンプを送信
       case latest_message.message_type
       when "text"

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -5,11 +5,11 @@ task :push_message => :environment do
   # 20分未満に送られたメッセージを新しい順に並べ、group_idごとに取得
   recent_message = Message.where(posted_at: time_20min_ago...).order(posted_at: "DESC").group_by{|message| message.group}
   recent_message.each do |group, messages|
-    group_id = group.group_id
+    line_group_id = group.line_group_id
     # 同じグループの中で一番新しいメッセージを取得
     latest_message = messages.first
     # 最新のメッセージが現在時刻より10分以上前に送られている場合、最後の一言と判断してpush_messageを送信
-    if latest_message.posted_at <= time_10min_ago
+    if latest_message.posted_at >= time_10min_ago
       # 最後のメッセージがテキストならテキスト、それ以外ならスタンプを送信
       case latest_message.message_type
       when "text"
@@ -17,24 +17,23 @@ task :push_message => :environment do
           type: 'text',
           text: pickup_random_text('positive')
         }
-        client.push_message(group_id, message)
+        client.push_message(line_group_id, message)
         # 個人へのメッセージを送信
         message = {
           type: 'text',
           text: "あなたの最後の一言「#{latest_message.text}」によってグループの会話が止まりました。"
         }
-        client.push_message(latest_message.user_id, message)
+        client.push_message(latest_message.user.line_user_id, message)
       else
         message = {
           type: "sticker",
           packageId: STICKER_PACKAGE_ID,
           stickerId: pickup_random_sticker_id
         }
-        client.push_message(group_id, message)
+        client.push_message(line_group_id, message)
       end
     end
   end
-  
 end
 
 private

--- a/test/fixtures/group_users.yml
+++ b/test/fixtures/group_users.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  group: one
+
+two:
+  user: two
+  group: two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/group_user_test.rb
+++ b/test/models/group_user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 実装の背景・目的
今まではuser_idをmessageに直接追加していたため、usersテーブルを追加してリレーション先から値を取ってくるように変更する。
usersテーブル追加に伴ってuserとgroupの中間テーブルを作成する。

## やったこと
- groupsテーブルのカラム名がgroup_idで分かりにくかったため、line_group_idに変更
- userテーブル、group_usersのテーブルを作成、それに伴ってmessageにuser.idを保存するように変更
- messageを受信した際に、usersテーブルにuser_idがない場合新たに保存する
- 中間テーブルについても同様に、line_user_id, line_group_id共に被っている物がない場合新たに保存する